### PR TITLE
Enable unit-testing

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -1,0 +1,5 @@
+from platformio.public import PlatformBase
+
+class QutyPlatform(PlatformBase):
+    def is_embedded(self):
+        return True


### PR DESCRIPTION
Tells PlatformIO that this is an embedded platform to nudge it into the right codepaths when unit-testing, otherwise it thinks it's a native platform and tries to execute the built AVR firmwares on the host computer for testing (which of course doesn't work).

See https://github.com/platformio/platformio-core/issues/4423